### PR TITLE
Refactor of bucket notification API.

### DIFF
--- a/examples/bucket-exists.js
+++ b/examples/bucket-exists.js
@@ -20,7 +20,7 @@
 
 var Minio = require('minio')
 
-var s3Client = new Minio({
+var s3Client = new Minio.Client({
   endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'

--- a/examples/delete-bucket-notification.js
+++ b/examples/delete-bucket-notification.js
@@ -18,18 +18,18 @@
  // dummy values, please replace them with original values.
 
 
-var Minio = require('minio').default
+var Minio = require('minio')
 
-var s3Client = new Minio({
+var s3Client = new Minio.Client({
   endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'
 })
 
-s3Client.deleteBucketNotification('my-bucketname', function(e) {
+s3Client.removeAllBucketNotification('my-bucketname', function(e) {
   if (e) {
     return console.log(e)
   }
-  console.log("True")
+  console.log("Success")
 })
 

--- a/examples/fget-object.js
+++ b/examples/fget-object.js
@@ -19,7 +19,7 @@
 
 var Minio = require('minio')
 
-var s3Client = new Minio({
+var s3Client = new Minio.Client({
   endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'

--- a/examples/fput-object.js
+++ b/examples/fput-object.js
@@ -20,7 +20,7 @@
 var Minio = require('minio')
 var Fs = require('fs')
 
-var s3Client = new Minio({
+var s3Client = new Minio.Client({
   endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'

--- a/examples/get-bucket-notification.js
+++ b/examples/get-bucket-notification.js
@@ -18,9 +18,9 @@
  // dummy values, please replace them with original values.
 
 
-var Minio = require('minio').default
+var Minio = require('minio')
 
-var s3Client = new Minio({
+var s3Client = new Minio.Client({
   endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'

--- a/examples/get-object.html
+++ b/examples/get-object.html
@@ -3,7 +3,7 @@
   <body>
     <script type="text/javascript" src="minio-browser.js"></script>
     <script>
-      var s3Client = new Minio({
+      var s3Client = new Minio.Client({
         endPoint: 's3.amazonaws.com',
         accessKey: 'YOUR-ACCESSKEYID',
         secretKey: 'YOUR-SECRETACCESSKEY'

--- a/examples/get-object.js
+++ b/examples/get-object.js
@@ -19,7 +19,7 @@
 
 var Minio = require('minio')
 
-var s3Client = new Minio({
+var s3Client = new Minio.Client({
   endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'

--- a/examples/get-partialobject.js
+++ b/examples/get-partialobject.js
@@ -20,7 +20,7 @@
 
 var Minio = require('minio')
 
-var s3Client = new Minio({
+var s3Client = new Minio.Client({
   endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'

--- a/examples/list-buckets.js
+++ b/examples/list-buckets.js
@@ -19,7 +19,7 @@
 
 var Minio = require('minio')
 
-var s3Client = new Minio({
+var s3Client = new Minio.Client({
   endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'

--- a/examples/list-incomplete-uploads.js
+++ b/examples/list-incomplete-uploads.js
@@ -19,7 +19,7 @@
 
 var Minio = require('minio')
 
-var s3Client = new Minio({
+var s3Client = new Minio.Client({
     endPoint: 's3.amazonaws.com',
     accessKey: 'YOUR-ACCESSKEYID',
     secretKey: 'YOUR-SECRETACCESSKEY'

--- a/examples/list-objects.js
+++ b/examples/list-objects.js
@@ -19,7 +19,7 @@
 
 var Minio = require('minio')
 
-var s3Client = new Minio({
+var s3Client = new Minio.Client({
   endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'

--- a/examples/make-bucket.js
+++ b/examples/make-bucket.js
@@ -19,7 +19,7 @@
 
 var Minio = require('minio')
 
-var s3Client = new Minio({
+var s3Client = new Minio.Client({
   endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'

--- a/examples/presigned-getobject.js
+++ b/examples/presigned-getobject.js
@@ -19,7 +19,7 @@
 
 var Minio = require('minio')
 
-var s3Client = new Minio({
+var s3Client = new Minio.Client({
   endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY',

--- a/examples/presigned-postpolicy.js
+++ b/examples/presigned-postpolicy.js
@@ -19,7 +19,7 @@
 
 var Minio = require('minio')
 
-var s3Client = new Minio({
+var s3Client = new Minio.Client({
   endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY',

--- a/examples/presigned-putobject.js
+++ b/examples/presigned-putobject.js
@@ -19,7 +19,7 @@
 
 var Minio = require('minio')
 
-var s3Client = new Minio({
+var s3Client = new Minio.Client({
   endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY',

--- a/examples/put-object.js
+++ b/examples/put-object.js
@@ -20,7 +20,7 @@
 var Minio = require('minio')
 var Fs = require('fs')
 
-var s3Client = new Minio({
+var s3Client = new Minio.Client({
   endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'

--- a/examples/remove-bucket.js
+++ b/examples/remove-bucket.js
@@ -19,7 +19,7 @@
 
 var Minio = require('minio')
 
-var s3Client = new Minio({
+var s3Client = new Minio.Client({
   endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'

--- a/examples/remove-incomplete-upload.js
+++ b/examples/remove-incomplete-upload.js
@@ -20,7 +20,7 @@
 
 var Minio = require('minio')
 
-var s3Client = new Minio({
+var s3Client = new Minio.Client({
   endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'

--- a/examples/remove-object.js
+++ b/examples/remove-object.js
@@ -20,7 +20,7 @@
 
 var Minio = require('minio')
 
-var s3Client = new Minio({
+var s3Client = new Minio.Client({
   endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'

--- a/examples/set-bucket-notification.js
+++ b/examples/set-bucket-notification.js
@@ -19,10 +19,6 @@
 
 
 var Minio = require('minio')
-var Notification = Minio.Notification
-
-var config = new Notification.Config()
-var topic = new Notification.Topic()
 
 var s3Client = new Minio.Client({
   endPoint: 's3.amazonaws.com',
@@ -30,10 +26,13 @@ var s3Client = new Minio.Client({
   secretKey: 'YOUR-SECRETACCESSKEY'
 })
 
-topic.addResource('TestTopic')
+var config = new Minio.NotificationConfig()
+var arn = Minio.buildARN('aws', 'sns', 'us-east-1', 111112222233, 'topicresource')
+var topic = new Minio.TopicConfig(arn)
+
 topic.addFilterSuffix('.jpg')
 topic.addFilterPrefix('myphotos/')
-topic.addEvent(Notification.Event.ObjectCreatedAll)
+topic.addEvent(Minio.ObjectCreatedAll)
 
 config.add(topic)
 

--- a/examples/set-bucket-notification.js
+++ b/examples/set-bucket-notification.js
@@ -18,29 +18,26 @@
  // dummy values, please replace them with original values.
 
 
-var Minio = require('minio').default
-var BucketNotification = require('minio').BucketNotification
-var TopicConfig = require('minio').TopicConfig
-var ObjectCreatedAll = require('minio').ObjectCreatedAll
-var newARN = require('minio').newARN
+var Minio = require('minio')
+var Notification = Minio.Notification
 
-var s3Client = new Minio({
+var config = new Notification.Config()
+var topic = new Notification.Topic()
+
+var s3Client = new Minio.Client({
   endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'
 })
 
-var bucketNotification = new BucketNotification();
-var arn = newARN('aws', 'sns', 'us-west-2', '408011449174', 'TestTopic')
-
-var topic = new TopicConfig(arn)
+topic.addResource('TestTopic')
 topic.addFilterSuffix('.jpg')
 topic.addFilterPrefix('myphotos/')
-topic.addEvent(ObjectCreatedAll)
+topic.addEvent(Notification.Event.ObjectCreatedAll)
 
-bucketNotification.addTopicConfiguration(topic)
+config.add(topic)
 
-s3Client.setBucketNotification('my-bucketname', bucketNotification, function(e) {
+s3Client.setBucketNotification('my-bucketname', config, function(e) {
   if (e) {
     return console.log(e)
   }

--- a/examples/stat-object.js
+++ b/examples/stat-object.js
@@ -20,7 +20,7 @@
 
 var Minio = require('minio')
 
-var s3Client = new Minio({
+var s3Client = new Minio.Client({
   endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'

--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -46,9 +46,11 @@ import * as errors from './errors.js';
 
 import { getS3Endpoint } from './s3-endpoints.js';
 
+import { Notification } from './notification'
+
 var Package = require('../../package.json');
 
-export default class Client {
+export class Client {
   constructor(params) {
     // Default values if not specified.
     if (typeof params.secure === 'undefined') params.secure = true
@@ -1786,23 +1788,40 @@ export default class Client {
     return simpleUploader
   }
 
-   // Remove all the notification configurations in the S3 provider
-  setBucketNotification(bucketName, bucketNotification, cb) {
+  // Remove all the notification configurations in the S3 provider
+  setBucketNotification(bucketName, config, cb) {
     if (!isFunction(cb)) {
       throw new TypeError('callback should be of type "function"')
     }
-    var method = 'PUT'
-    var query = 'notification'
-    var builder = new xml2js.Builder({rootName:'NotificationConfiguration', renderOpts:{'pretty':false}, headless:true});
-    var payload = builder.buildObject(bucketNotification.data)
-    this.makeRequest({method, bucketName, query}, payload, 200, '', (e, response) => {
+    this.getBucketRegion(bucketName, (e, region) => {
       if (e) return cb(e)
-      cb(null)
+      let partition = 'minio'
+      if (isAmazonEndpoint(this.host)) partition = 'aws'
+      let updateARN = (target) => {
+	if (!target[target.arnTag]) {
+	  target[target.arnTag] = `arn:${partition}:${target.service}:${region}:${this.accessKey}:${target.resource}`
+	}
+	delete(target.resource)
+	delete(target.service)
+	delete(target.arnTag)
+	return target
+      }
+      Object.keys(config).forEach(key => {
+	config[key] = config[key].map(updateARN)
+      })
+      var method = 'PUT'
+      var query = 'notification'
+      var builder = new xml2js.Builder({rootName:'NotificationConfiguration', renderOpts:{'pretty':false}, headless:true});
+      var payload = builder.buildObject(config)
+      this.makeRequest({method, bucketName, query}, payload, 200, '', (e, response) => {
+	if (e) return cb(e)
+	cb(null)
+      })
     })
   }
 
   deleteBucketNotification(bucketName, cb) {
-    this.setBucketNotification(bucketName, new BucketNotification(), cb)
+    this.setBucketNotification(bucketName, new Notification.Config(), cb)
   }
 
   // Return the list of notification configurations stored
@@ -1901,80 +1920,4 @@ export class PostPolicy {
   }
 }
 
-exports.ObjectCreatedAll                      = "s3:ObjectCreated:*"
-exports.ObjectCreatePut                       = "s3:ObjectCreated:Put"
-exports.ObjectCreatedPost                     = "s3:ObjectCreated:Post"
-exports.ObjectCreatedCopy                     = "s3:ObjectCreated:Copy"
-exports.ObjectCreatedCompleteMultipartUpload  = "sh:ObjectCreated:CompleteMultipartUpload"
-exports.ObjectRemovedAll                      = "s3:ObjectRemoved:*"
-exports.ObjectRemovedDelete                   = "s3:ObjectRemoved:Delete"
-exports.ObjectRemovedDeleteMarkerCreated      = "s3:ObjectRemoved:DeleteMarkerCreated"
-exports.ObjectReducedRedundancyLostObject     = "s3:ReducedRedundancyLostObject"
-
-export class BucketNotification {
-  constructor() {
-    this.data = {TopicConfiguration:[], QueueConfiguration:[], CloudFunctionConfiguration:[]}
-  }
-  addTopicConfiguration(topic) {
-    this.data.TopicConfiguration.push(topic.data)
-  }
-  addQueueConfiguration(queue) {
-    this.data.QueueConfiguration.push(queue.data)
-  }
-  addCloudFunctionConfiguration(cloudfunction) {
-    this.data.CloudFunctionConfiguration.push(cloudfunction.data)
-  }
-}
-
-export class NotificationConfig {
-  constructor() {
-    this.data = {Id:'', Event:[], Filter:[]}
-  }
-  setId(id) {
-    this.data.Id = id
-  }
-  addEvent(newevent){
-    this.data.Event.push(newevent)
-  }
-  addFilterSuffix(suffix) {
-    if (this.data.Filter.S3Key === undefined) {
-      this.data.Filter = {S3Key : {FilterRule:[]}}
-    }
-    this.data.Filter.S3Key.FilterRule.push({Name:"suffix", Value:suffix})
-  }
-  addFilterPrefix(prefix) {
-    if (this.data.Filter.S3Key === undefined) {
-      this.data.Filter = {S3Key : {FilterRule:[]}}
-    }
-    this.data.Filter.S3Key.FilterRule.push({Name:"prefix", Value:prefix})
-  }
-}
-
-export class TopicConfig extends NotificationConfig {
-  constructor(arn) {
-    super();
-    this.data.Topic = arn
-  }
-}
-
-export class QueueConfig extends NotificationConfig {
-  constructor(arn) {
-    super();
-    this.data.Queue = arn
-  }
-}
-
-export class CloudFunctionConfig extends NotificationConfig {
-  constructor(arn) {
-    super();
-    this.data.CloudFunction = arn
-  }
-}
-
-exports.newBucketNotification = function() {
-    return new BucketNotification()
-}
-
-exports.newARN = function(partition, service, region, accountId, resource) {
-    return "arn:" + partition + ":" + service + ":" + region + ":" + accountId + ":" + resource
-}
+export {Notification} from './notification'

--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -46,7 +46,7 @@ import * as errors from './errors.js';
 
 import { getS3Endpoint } from './s3-endpoints.js';
 
-import { Notification } from './notification'
+import { NotificationConfig } from './notification'
 
 var Package = require('../../package.json');
 
@@ -1807,7 +1807,7 @@ export class Client {
   }
 
   removeAllBucketNotification(bucketName, cb) {
-    this.setBucketNotification(bucketName, new Notification.NotificationConfig(), cb)
+    this.setBucketNotification(bucketName, new NotificationConfig(), cb)
   }
 
   // Return the list of notification configurations stored

--- a/src/main/notification.js
+++ b/src/main/notification.js
@@ -1,0 +1,102 @@
+/*
+ * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Notification config - array of target configs.
+// Target configs can be
+// 1. Topic (simple notification service)
+// 2. Queue (simple queue service)
+// 3. CloudFront (lambda function)
+export class NotificationConfig {
+  add(target) {
+    // type can be : TopicConfiguration QueueConfiguration CloudFunctionConfiguration
+    var type = target.type
+    delete(target.type)
+    if (!this[type]) this[type] = []
+    this[type].push(target)
+  }
+}
+
+// Base class for three supported configs.
+class TargetConfig {
+  setResource(resource) {
+    this.resource = resource
+  }
+  setId(id) {
+    this.Id = id
+  }
+  addEvent(newevent){
+    if (!this.Event) this.Event = []
+    this.Event.push(newevent)
+  }
+  addFilterSuffix(suffix) {
+    if (!this.Filter) this.Filter = {S3Key : {FilterRule:[]}}
+    this.Filter.S3Key.FilterRule.push({Name:"suffix", Value:suffix})
+  }
+  addFilterPrefix(prefix) {
+    if (!this.Filter) this.Filter = {S3Key : {FilterRule:[]}}
+    this.Filter.S3Key.FilterRule.push({Name:"prefix", Value:prefix})
+  }
+}
+
+// 1. Topic (simple notification service)
+class TopicConfig extends TargetConfig {
+  constructor() {
+    super();
+    this.type = 'TopicConfiguration'
+    this.service = 'sns'
+    this.arnTag = 'Topic'
+  }
+}
+
+// 2. Queue (simple queue service)
+class QueueConfig extends TargetConfig {
+  constructor() {
+    super();
+    this.type = 'QueueConfiguration'
+    this.service = 'sqs'
+    this.arnTag = 'Queue'
+  }
+}
+
+// 3. CloudFront (lambda function)
+class CloudFunctionConfig extends TargetConfig {
+  constructor() {
+    super();
+    this.type = 'CloudFunctionConfiguration'
+    this.service = 'sqs'
+    this.arnTag = 'CloudFunction'
+  }
+}
+
+// Namespace for all the notification related features.
+export var Notification = {
+  Config: NotificationConfig,
+  Topic: TopicConfig,
+  Queue: QueueConfig,
+  CloudFunction: CloudFunctionConfig,
+  Event: {
+    ObjectCreatedAll                      : "s3:ObjectCreated:*",
+    ObjectCreatedPut                       : "s3:ObjectCreated:Put",
+    ObjectCreatedPost                     : "s3:ObjectCreated:Post",
+    ObjectCreatedCopy                     : "s3:ObjectCreated:Copy",
+    ObjectCreatedCompleteMultipartUpload  : "sh:ObjectCreated:CompleteMultipartUpload",
+    ObjectRemovedAll                      : "s3:ObjectRemoved:*",
+    ObjectRemovedDelete                   : "s3:ObjectRemoved:Delete",
+    ObjectRemovedDeleteMarkerCreated      : "s3:ObjectRemoved:DeleteMarkerCreated",
+    ObjectReducedRedundancyLostObject     : "s3:ReducedRedundancyLostObject",
+  }
+}
+

--- a/src/main/notification.js
+++ b/src/main/notification.js
@@ -21,19 +21,23 @@
 // 3. CloudFront (lambda function)
 export class NotificationConfig {
   add(target) {
-    // type can be : TopicConfiguration QueueConfiguration CloudFunctionConfiguration
-    var type = target.type
-    delete(target.type)
-    if (!this[type]) this[type] = []
-    this[type].push(target)
+    let instance = ''
+    if (target instanceof TopicConfig) {
+      instance = 'TopicConfiguration'
+    }
+    if (target instanceof QueueConfig) {
+      instance = 'QueueConfiguration'
+    }
+    if (target instanceof CloudFunctionConfig) {
+      instance = 'CloudFunctionConfiguration'
+    }
+    if (!this[instance]) this[instance] = []
+    this[instance].push(target)
   }
 }
 
 // Base class for three supported configs.
 class TargetConfig {
-  setResource(resource) {
-    this.resource = resource
-  }
   setId(id) {
     this.Id = id
   }
@@ -52,51 +56,40 @@ class TargetConfig {
 }
 
 // 1. Topic (simple notification service)
-class TopicConfig extends TargetConfig {
-  constructor() {
+export class TopicConfig extends TargetConfig {
+  constructor(arn) {
     super();
-    this.type = 'TopicConfiguration'
-    this.service = 'sns'
-    this.arnTag = 'Topic'
+    this.Topic = arn
   }
 }
 
 // 2. Queue (simple queue service)
-class QueueConfig extends TargetConfig {
-  constructor() {
+export class QueueConfig extends TargetConfig {
+  constructor(arn) {
     super();
-    this.type = 'QueueConfiguration'
-    this.service = 'sqs'
-    this.arnTag = 'Queue'
+    this.Queue = arn
   }
 }
 
 // 3. CloudFront (lambda function)
-class CloudFunctionConfig extends TargetConfig {
-  constructor() {
+export class CloudFunctionConfig extends TargetConfig {
+  constructor(arn) {
     super();
-    this.type = 'CloudFunctionConfiguration'
-    this.service = 'sqs'
-    this.arnTag = 'CloudFunction'
+    this.CloudFunction = arn
   }
 }
 
-// Namespace for all the notification related features.
-export var Notification = {
-  Config: NotificationConfig,
-  Topic: TopicConfig,
-  Queue: QueueConfig,
-  CloudFunction: CloudFunctionConfig,
-  Event: {
-    ObjectCreatedAll                      : "s3:ObjectCreated:*",
-    ObjectCreatedPut                       : "s3:ObjectCreated:Put",
-    ObjectCreatedPost                     : "s3:ObjectCreated:Post",
-    ObjectCreatedCopy                     : "s3:ObjectCreated:Copy",
-    ObjectCreatedCompleteMultipartUpload  : "sh:ObjectCreated:CompleteMultipartUpload",
-    ObjectRemovedAll                      : "s3:ObjectRemoved:*",
-    ObjectRemovedDelete                   : "s3:ObjectRemoved:Delete",
-    ObjectRemovedDeleteMarkerCreated      : "s3:ObjectRemoved:DeleteMarkerCreated",
-    ObjectReducedRedundancyLostObject     : "s3:ReducedRedundancyLostObject",
-  }
+export const buildARN = (partition, service, region, accountId, resource) => {
+  return "arn:" + partition + ":" + service + ":" + region + ":" + accountId + ":" + resource
 }
 
+
+export const ObjectCreatedAll                      = "s3:ObjectCreated:*"
+export const ObjectCreatedPut                      = "s3:ObjectCreated:Put"
+export const ObjectCreatedPost                     = "s3:ObjectCreated:Post"
+export const ObjectCreatedCopy                     = "s3:ObjectCreated:Copy"
+export const ObjectCreatedCompleteMultipartUpload  = "sh:ObjectCreated:CompleteMultipartUpload"
+export const ObjectRemovedAll                      = "s3:ObjectRemoved:*"
+export const ObjectRemovedDelete                   = "s3:ObjectRemoved:Delete"
+export const ObjectRemovedDeleteMarkerCreated      = "s3:ObjectRemoved:DeleteMarkerCreated"
+export const ObjectReducedRedundancyLostObject     = "s3:ReducedRedundancyLostObject"

--- a/src/test/unit/test.js
+++ b/src/test/unit/test.js
@@ -22,14 +22,7 @@ import Http from 'http';
 import Nock from 'nock';
 import Through2 from 'through2';
 import Stream from 'stream';
-import Minio from '../../../dist/main/minio.js';
-
-var BucketNotification = require('../../../dist/main/minio.js').BucketNotification
-var TopicConfig = require('../../../dist/main/minio.js').TopicConfig
-var QueueConfig = require('../../../dist/main/minio.js').QueueConfig
-var ObjectReducedRedundancyLostObject = require('../../../dist/main/minio.js').ObjectReducedRedundancyLostObject
-var ObjectCreatedAll = require('../../../dist/main/minio.js').ObjectCreatedAll
-var newARN = require('../../../dist/main/minio.js').newARN
+import * as Minio from '../../../dist/main/minio';
 
 var Package = require('../../../package.json')
 
@@ -56,7 +49,7 @@ describe('Client', function() {
       })
       return request
     },
-    client = new Minio({
+    client = new Minio.Client({
       endPoint: 'localhost',
       port: 9000,
       accessKey: 'accesskey',
@@ -65,7 +58,7 @@ describe('Client', function() {
     })
   describe('new client', () => {
     it('should work with https', () => {
-      var client = new Minio({
+      var client = new Minio.Client({
         endPoint: 'localhost',
         accessKey: 'accesskey',
         secretKey: 'secretkey'
@@ -73,7 +66,7 @@ describe('Client', function() {
       assert.equal(client.port, 443)
     })
     it('should override port with http', () => {
-      var client = new Minio({
+      var client = new Minio.Client({
         endPoint: 'localhost',
         port: 9000,
         accessKey: 'accesskey',
@@ -83,7 +76,7 @@ describe('Client', function() {
       assert.equal(client.port, 9000)
     })
     it('should work with http', () => {
-      var client = new Minio({
+      var client = new Minio.Client({
         endPoint: 'localhost',
         accessKey: 'accesskey',
         secretKey: 'secretkey',
@@ -92,7 +85,7 @@ describe('Client', function() {
       assert.equal(client.port, 80)
     })
     it('should override port with https', () => {
-      var client = new Minio({
+      var client = new Minio.Client({
         endPoint: 'localhost',
         port: 9000,
         accessKey: 'accesskey',
@@ -102,7 +95,7 @@ describe('Client', function() {
     })
     it('should fail with url', (done) => {
       try {
-        new Minio({
+        new Minio.Client({
           endPoint: 'http://localhost:9000',
           accessKey: 'accesskey',
           secretKey: 'secretkey'
@@ -113,7 +106,7 @@ describe('Client', function() {
     })
     it('should fail with alphanumeric', (done) => {
       try {
-        new Minio({
+        new Minio.Client({
           endPoint: 'localhost##$@3',
           accessKey: 'accesskey',
           secretKey: 'secretkey'
@@ -124,7 +117,7 @@ describe('Client', function() {
     })
     it('should fail with no url', (done) => {
       try {
-        new Minio({
+        new Minio.Client({
           accessKey: 'accesskey',
           secretKey: 'secretkey'
         })
@@ -134,7 +127,7 @@ describe('Client', function() {
     })
     it('should fail with bad port', (done) => {
       try {
-        new Minio({
+        new Minio.Client({
           endPoint: 'localhost',
           port: -1,
           accessKey: 'accesskey',
@@ -149,7 +142,7 @@ describe('Client', function() {
     describe('presigned-get', () => {
       it('should not generate presigned url with no access key', (done) => {
         try {
-          var client = new Minio({
+          var client = new Minio.Client({
             endPoint: 'localhost',
             port: 9000,
             secure: false
@@ -178,7 +171,7 @@ describe('Client', function() {
     describe('presigned-put', () => {
       it('should not generate presigned url with no access key', (done) => {
         try {
-          var client = new Minio({
+          var client = new Minio.Client({
             endPoint: 'localhost',
             port: 9000,
             secure: false
@@ -206,7 +199,7 @@ describe('Client', function() {
   })
   describe('User Agent', () => {
     it('should have a default user agent', () => {
-      var client = new Minio({
+      var client = new Minio.Client({
         endPoint: 'localhost',
         accessKey: 'accesskey',
         secretKey: 'secretkey'
@@ -215,7 +208,7 @@ describe('Client', function() {
                    client.userAgent)
     })
     it('should set user agent', () => {
-      var client = new Minio({
+      var client = new Minio.Client({
         endPoint: 'localhost',
         accessKey: 'accesskey',
         secretKey: 'secretkey'
@@ -225,7 +218,7 @@ describe('Client', function() {
                    client.userAgent)
     })
     it('should set user agent without comments', () => {
-      var client = new Minio({
+      var client = new Minio.Client({
         endPoint: 'localhost',
         accessKey: 'accesskey',
         secretKey: 'secretkey'
@@ -236,7 +229,7 @@ describe('Client', function() {
     })
     it('should not set user agent without name', (done) => {
       try {
-        var client = new Minio({
+        var client = new Minio.Client({
           endPoint: 'localhost',
           accessKey: 'accesskey',
           secretKey: 'secretkey'
@@ -248,7 +241,7 @@ describe('Client', function() {
     })
     it('should not set user agent with empty name', (done) => {
       try {
-        var client = new Minio({
+        var client = new Minio.Client({
           endPoint: 'localhost',
           accessKey: 'accesskey',
           secretKey: 'secretkey'
@@ -260,7 +253,7 @@ describe('Client', function() {
     })
     it('should not set user agent without version', (done) => {
       try {
-        var client = new Minio({
+        var client = new Minio.Client({
           endPoint: 'localhost',
           accessKey: 'accesskey',
           secretKey: 'secretkey'
@@ -272,7 +265,7 @@ describe('Client', function() {
     })
     it('should not set user agent with empty version', (done) => {
       try {
-        var client = new Minio({
+        var client = new Minio.Client({
           endPoint: 'localhost',
           accessKey: 'accesskey',
           secretKey: 'secretkey'
@@ -286,7 +279,7 @@ describe('Client', function() {
   describe('Authentication', () => {
     describe('not set', () => {
       it('should not send auth info without keys', (done) => {
-        client = new Minio({
+        client = new Minio.Client({
           endPoint: 'localhost',
           port: 9000,
           secure: false
@@ -313,7 +306,7 @@ describe('Client', function() {
     })
     describe('set with access and secret keys', () => {
       it('should not send auth info without keys', (done) => {
-        client = new Minio({
+        client = new Minio.Client({
           endPoint: 'localhost',
           port: 9000,
           accessKey: 'accessKey',
@@ -876,59 +869,9 @@ describe('Client', function() {
       })
     })
 
-
-    describe('#deleteBucketNotification()', () => {
-      it('remove all bucket notifications', (done) => {
-        MockResponse('http://localhost:9000').get('/bucket?location').reply(200, '<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">EU</LocationConstraint>')
-          MockResponse('http://localhost:9000').put('/bucket?notification').reply(200, '')
-          client.deleteBucketNotification('bucket', function(e) {
-            assert.equal(e, null)
-            done()
-          })
-      })
-    })
-
-    describe('#setBucketNotification()', () => {
-      it('set a bucket notification', (done) => {
-        MockResponse('http://localhost:9000').put('/bucket?notification').reply(200, '')
-         var bucketNotification = new BucketNotification()
-         var arn1 = newARN('aws', 'sns', 'us-east-1', '83310034', 's3notificationtopic2')
-         var topic = new TopicConfig(arn1)
-         topic.setId('YjVkM2Y0YmUtNGI3NC00ZjQyLWEwNGItNDIyYWUxY2I0N2M4');
-         topic.addFilterSuffix('.jpg')
-         topic.addFilterPrefix('photos/')
-         topic.addEvent(ObjectReducedRedundancyLostObject)
-         topic.addEvent(ObjectCreatedAll)
-         bucketNotification.addTopicConfiguration(topic)
-         var arn2 = newARN('aws', 'sqs', 'us-east-1', '83310034', 's3notificationqueue2')
-         var queue = new QueueConfig(arn2)
-         queue.setId('ZjVkM2Y0YmUtNGI3NC00ZjQyLWEwNGItNDIyYWUxY2I0N2M4')
-         queue.addEvent(ObjectCreatedAll)
-         bucketNotification.addQueueConfiguration(queue)
-
-        client.setBucketNotification('bucket', bucketNotification, function(e) {
-          assert.equal(e, null)
-          done()
-        })
-      })
-    })
-
-    describe('#getBucketNotification()', () => {
-      it('get and parse a bucket notification response', (done) => {
-        MockResponse('http://localhost:9000').get('/bucket?notification').reply(200, '<NotificationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><TopicConfiguration><Id>YjVkM2Y0YmUtNGI3NC00ZjQyLWEwNGItNDIyYWUxY2I0N2M4</Id><Topic>arn:aws:sns:us-east-1:83310034:s3notificationtopic2</Topic><Event>s3:ReducedRedundancyLostObject</Event><Event>s3:ObjectCreated:*</Event><Filter><S3Key><FilterRule><Name>suffix</Name><Value>.jpg</Value></FilterRule><FilterRule><Name>prefix</Name><Value>photos/</Value></FilterRule></S3Key></Filter></TopicConfiguration><QueueConfiguration><Id>ZjVkM2Y0YmUtNGI3NC00ZjQyLWEwNGItNDIyYWUxY2I0N2M4</Id><Queue>arn:aws:sns:us-east-1:83310034:s3notificationqueue2</Queue><Event>s3:ReducedRedundancyLostObject</Event><Event>s3:ObjectCreated:*</Event></QueueConfiguration></NotificationConfiguration>')
-        client.getBucketNotification('bucket', function(e, bucketNotification) {
-        var expectedResults = {
-          TopicConfiguration:[{ Id: 'YjVkM2Y0YmUtNGI3NC00ZjQyLWEwNGItNDIyYWUxY2I0N2M4', Topic:'arn:aws:sns:us-east-1:83310034:s3notificationtopic2', Event:['s3:ReducedRedundancyLostObject', 's3:ObjectCreated:*'], Filter:[{Name:'suffix', Value:'.jpg'}, {Name:'prefix', Value:'photos/'}]}],
-         QueueConfiguration:[ { Id: 'ZjVkM2Y0YmUtNGI3NC00ZjQyLWEwNGItNDIyYWUxY2I0N2M4', Queue:'arn:aws:sns:us-east-1:83310034:s3notificationqueue2', Event:['s3:ReducedRedundancyLostObject', 's3:ObjectCreated:*'], Filter:[]}],
-          CloudFunctionConfiguration:[]}
-        assert.deepEqual(bucketNotification, expectedResults)
-	done()
-        })
-      })
-    })
-
     describe('#listObjects()', () => {
       it('should iterate without a prefix', (done) => {
+	MockResponse('http://localhost:9000').get('/bucket?location').reply(200, '<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">EU</LocationConstraint>')
         MockResponse('http://localhost:9000').get('/bucket?max-keys=1000').reply(200, '<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01"><Name>bucket</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><Delimiter></Delimiter><IsTruncated>true</IsTruncated><Contents><Key>key1</Key><LastModified>2015-05-05T02:21:15.716Z</LastModified><ETag>"5eb63bbbe01eeed093cb22bb8f5acdc3"</ETag><Size>11</Size><StorageClass>STANDARD</StorageClass><Owner><ID>minio</ID><DisplayName>minio</DisplayName></Owner></Contents><Contents><Key>key2</Key><LastModified>2015-05-05T20:36:17.498Z</LastModified><ETag>"2a60eaffa7a82804bdc682ce1df6c2d4"</ETag><Size>1661</Size><StorageClass>STANDARD</StorageClass><Owner><ID>minio</ID><DisplayName>minio</DisplayName></Owner></Contents></ListBucketResult>')
         MockResponse('http://localhost:9000').get('/bucket?marker=key2&max-keys=1000').reply(200, '<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01"><Name>bucket</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><Delimiter></Delimiter><IsTruncated>true</IsTruncated><Contents><Key>key3</Key><LastModified>2015-05-05T02:21:15.716Z</LastModified><ETag>"5eb63bbbe01eeed093cb22bb8f5acdc3"</ETag><Size>11</Size><StorageClass>STANDARD</StorageClass><Owner><ID>minio</ID><DisplayName>minio</DisplayName></Owner></Contents><Contents><Key>key4</Key><LastModified>2015-05-05T20:36:17.498Z</LastModified><ETag>"2a60eaffa7a82804bdc682ce1df6c2d4"</ETag><Size>1661</Size><StorageClass>STANDARD</StorageClass><Owner><ID>minio</ID><DisplayName>minio</DisplayName></Owner></Contents></ListBucketResult>')
         MockResponse('http://localhost:9000').get('/bucket?marker=key4&max-keys=1000').reply(200, '<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01"><Name>bucket</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><Delimiter></Delimiter><IsTruncated>false</IsTruncated><Contents><Key>key5</Key><LastModified>2015-05-05T02:21:15.716Z</LastModified><ETag>"5eb63bbbe01eeed093cb22bb8f5acdc3"</ETag><Size>11</Size><StorageClass>STANDARD</StorageClass><Owner><ID>minio</ID><DisplayName>minio</DisplayName></Owner></Contents><Contents><Key>key6</Key><LastModified>2015-05-05T20:36:17.498Z</LastModified><ETag>"2a60eaffa7a82804bdc682ce1df6c2d4"</ETag><Size>1661</Size><StorageClass>STANDARD</StorageClass><Owner><ID>minio</ID><DisplayName>minio</DisplayName></Owner></Contents></ListBucketResult>')


### PR DESCRIPTION
- move notification APIs into its own namespace
- no need for arn awareness of notification targets for developer as it is figured out automatically (we can give addARN() API to override if requred i.e when target is in a different region than bucket, it would be rare. For minio it's just one region)
- notification.config.add() can be used to add targets, no need for separate addTopicConfiguration, addQueueConfiguration, addCloudFunctionConfiguration
